### PR TITLE
75 category item menu

### DIFF
--- a/app/src/components/category-item-menu.js
+++ b/app/src/components/category-item-menu.js
@@ -1,0 +1,84 @@
+import React from 'react'
+import IconButton from 'material-ui/IconButton'
+import Menu, { MenuItem } from 'material-ui/Menu'
+import MoreVertIcon from 'material-ui-icons/MoreVert'
+import { map, propOr } from 'ramda'
+import { Link } from 'react-router-dom'
+
+const ITEM_HEIGHT = 48
+
+class CategoryMenu extends React.Component {
+  state = {
+    anchorEl: null,
+    actions: this.props.actions
+  }
+
+  handleClick = event => {
+    this.setState({ anchorEl: event.currentTarget })
+  }
+
+  handleRequestClose = () => {
+    this.setState({ anchorEl: null })
+  }
+
+  render() {
+    const open = Boolean(this.state.anchorEl)
+    const actions = propOr([], 'actions', this.state)
+    console.log('props:', this.props)
+    console.log('state:', this.state)
+    console.log('options:', actions)
+    return (
+      <div>
+        <IconButton
+          aria-label="More"
+          aria-owns={open ? 'long-menu' : null}
+          aria-haspopup="true"
+          onClick={this.handleClick}
+        >
+          <MoreVertIcon />
+        </IconButton>
+        <Menu
+          id="long-menu"
+          anchorEl={this.state.anchorEl}
+          open={open}
+          onRequestClose={this.handleRequestClose}
+          PaperProps={{
+            style: {
+              maxHeight: ITEM_HEIGHT * 4.5,
+              width: 200
+            }
+          }}
+        >
+          {map(
+            action =>
+              action.link ? (
+                <Link
+                  key={action.name}
+                  to={action.link}
+                  className="no-underline no-focus"
+                >
+                  <MenuItem onClick={this.handleRequestClose}>
+                    {action.name}
+                  </MenuItem>
+                </Link>
+              ) : (
+                <Link
+                  key={action.name}
+                  to={'#'}
+                  onClick={action.fn}
+                  className="no-underline no-focus"
+                >
+                  <MenuItem onClick={this.handleRequestClose}>
+                    {action.name}
+                  </MenuItem>
+                </Link>
+              ),
+            actions
+          )}
+        </Menu>
+      </div>
+    )
+  }
+}
+
+export default CategoryMenu

--- a/app/src/components/category-item.js
+++ b/app/src/components/category-item.js
@@ -12,30 +12,44 @@ import IconButton from 'material-ui/IconButton'
 import EllipsisIcon from 'material-ui-icons/MoreVert'
 import Divider from 'material-ui/Divider'
 import Icon from 'material-ui/Icon'
+import CategoryMenu from './category-item-menu'
+import history from '../history'
 
 const CategoryItem = props => {
+  const menuItemActions = [
+    {
+      name: 'View Resources',
+      link: null,
+      fn: null
+    },
+    {
+      name: 'Details',
+      link: `/categories/${props._id}`,
+      fn: null
+    }
+  ]
   return (
     <div key={props._id}>
-      <Link
-        to={`/categories/${props._id}`}
-        style={{ textDecoration: 'none' }}
-        className="link"
+      <ListItem
+        button
+        onClick={e => {
+          e.preventDefault()
+          history.push(`/categories/${props._id}`)
+        }}
       >
-        <ListItem button>
-          <ListItemAvatar>
-            <Avatar>
-              <Icon>{props.icon ? props.icon : 'add_circle'}</Icon>
-            </Avatar>
-          </ListItemAvatar>
-          <ListItemText primary={props.name} secondary={props.shortDesc} />
+        <ListItemAvatar>
+          <Avatar>
+            <Icon>{props.icon ? props.icon : 'add_circle'}</Icon>
+          </Avatar>
+        </ListItemAvatar>
+        <ListItemText primary={props.name} secondary={props.shortDesc} />
 
-          <ListItemSecondaryAction>
-            <IconButton aria-label="More">
-              <EllipsisIcon />
-            </IconButton>
-          </ListItemSecondaryAction>
-        </ListItem>
-      </Link>
+        <ListItemSecondaryAction>
+          <IconButton aria-label="More">
+            <CategoryMenu actions={menuItemActions} {...this.props} />
+          </IconButton>
+        </ListItemSecondaryAction>
+      </ListItem>
       <Divider />
     </div>
   )


### PR DESCRIPTION
pop-out menu works on individual category list items. shows 'view resources' and 'details' and details link sends to that category-show page

Waiting to add functionality for view filtered resources until we add that functionality on the resources app bar. then i can history.push directly to that link. according to the wireframes that will be functionality. 